### PR TITLE
feat(fixtures): add tags and enrich video games

### DIFF
--- a/src/Doctrine/DataFixtures/TagFixtures.php
+++ b/src/Doctrine/DataFixtures/TagFixtures.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Doctrine\DataFixtures;
+
+use App\Model\Entity\Tag;
+use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Persistence\ObjectManager;
+use function array_fill_callback;
+
+final class TagFixtures extends Fixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $tags = array_fill_callback(
+            0,
+            25,
+            static fn (int $index): Tag => (new Tag)->setName(sprintf('Tag %d', $index))
+        );
+
+        array_walk($tags, [$manager, 'persist']);
+
+        $manager->flush();
+    }
+}

--- a/src/Doctrine/DataFixtures/VideoGameFixtures.php
+++ b/src/Doctrine/DataFixtures/VideoGameFixtures.php
@@ -2,6 +2,8 @@
 
 namespace App\Doctrine\DataFixtures;
 
+use App\Model\Entity\Review;
+use App\Model\Entity\Tag;
 use App\Model\Entity\User;
 use App\Model\Entity\VideoGame;
 use App\Rating\CalculateAverageRating;
@@ -25,30 +27,73 @@ final class VideoGameFixtures extends Fixture implements DependentFixtureInterfa
 
     public function load(ObjectManager $manager): void
     {
-        $users = $manager->getRepository(User::class)->findAll();
+        // on récupère tous les tags
+        $tags = $manager->getRepository(Tag::class)->findAll();
+        
+        $users = array_chunk(
+            $manager->getRepository(User::class)->findAll(),
+            5
+        );
+        
+        /** @var string $fakeText */
+        $fakeText = $this->faker->paragraphs(5, true);
 
         $videoGames = array_fill_callback(0, 50, fn (int $index): VideoGame => (new VideoGame)
             ->setTitle(sprintf('Jeu vidéo %d', $index))
             ->setDescription($this->faker->paragraphs(10, true))
             ->setReleaseDate(new DateTimeImmutable())
-            ->setTest($this->faker->paragraphs(6, true))
+            ->setTest($fakeText)
             ->setRating(($index % 5) + 1)
             ->setImageName(sprintf('video_game_%d.png', $index))
             ->setImageSize(2_098_872)
         );
 
-        // TODO : Ajouter les tags aux vidéos
 
+
+        array_walk($videoGames, static function (VideoGame $videoGame, int $index) use ($tags) {
+            // on choisit un nombre aléatoire entre 2 et 5 pour le nombre de tags d'un jeu
+            $numberOfTags = random_int(2, 5);
+
+            // on mélange pour ne pas avoir les mêmes
+            shuffle($tags);
+
+            for ($i = 0; $i < $numberOfTags; $i++) {
+                $videoGame->getTags()->add($tags[$i]);
+            }
+        });
+
+        // on ajoute les tags aux jeux
         array_walk($videoGames, [$manager, 'persist']);
 
         $manager->flush();
 
-        // TODO : Ajouter des reviews aux vidéos
+        array_walk($videoGames, function (VideoGame $videoGame, int $index) use ($users, $manager) {
+            $filteredUsers = $users[$index % count($users)];
+
+            foreach ($filteredUsers as $i => $user) {
+                /** @var string $comment */
+                $comment = $this->faker->paragraphs(1, true);
+
+                $review = (new Review())
+                    ->setUser($user)
+                    ->setVideoGame($videoGame)
+                    ->setRating($this->faker->numberBetween(1, 5))
+                    ->setComment($comment)
+                ;
+
+                $videoGame->getReviews()->add($review);
+
+                $manager->persist($review);
+
+                $this->calculateAverageRating->calculateAverage($videoGame);
+                $this->countRatingsPerValue->countRatingsPerValue($videoGame);
+            }
+        });
 
     }
 
     public function getDependencies(): array
     {
-        return [UserFixtures::class];
+        return [TagFixtures::class, UserFixtures::class];
     }
 }


### PR DESCRIPTION
-Added a set of tag fixtures and persisted them to the database.

-Assigned 2 to 5 random tags to each created video game.

- Generated reviews for each game with random users, ratings, and optional comments.

- Automatically calculated the average rating and the number of ratings per value after creating reviews.